### PR TITLE
Better handling for cookie tests

### DIFF
--- a/src/main/java/org/core/Application.java
+++ b/src/main/java/org/core/Application.java
@@ -71,7 +71,7 @@ public class Application {
 
                     try {
                         Request request = Http.request(reader);
-                        System.out.println(String.format("%s: %s %s HTTP/1.1", LocalDateTime.now(), request.getMethod(), request.getRequestTarget()));
+                        System.out.println(String.format("%s: %s %s HTTP/1.1", LocalDateTime.now(), request.getMethod(), request.getRequestTarget().toString()));
                         response = getServer().handle(request);
                         writeHttpMessage(response, os);
                     } catch (IOException ioe) {

--- a/src/main/java/org/core/Cookie.java
+++ b/src/main/java/org/core/Cookie.java
@@ -1,0 +1,38 @@
+package org.core;
+
+import javaslang.collection.HashMap;
+import javaslang.control.Option;
+
+import static org.core.parse.Cookie.*;
+
+public class Cookie {
+    private HashMap<String, String> cookie;
+
+    public Cookie() {
+        this.cookie = HashMap.empty();
+    }
+
+    public Cookie(String content) {
+        this.cookie = PARSER.parse(content);
+    }
+
+    public boolean isEmpty() {
+        return cookie.isEmpty();
+    }
+
+    public Option<String> get(String key) {
+        return cookie.get(key);
+    }
+
+    public void put(String key, String value) {
+        cookie = cookie.put(key, value);
+    }
+
+    @Override
+    public String toString() {
+        return cookie
+            .map((entry) -> entry._1 + "=" + entry._2)
+            .intersperse("; ")
+            .reduce(String::concat);
+    }
+}

--- a/src/main/java/org/core/FormUrlencoded.java
+++ b/src/main/java/org/core/FormUrlencoded.java
@@ -1,0 +1,53 @@
+package org.core;
+
+import javaslang.Tuple2;
+import javaslang.collection.HashMap;
+import javaslang.collection.Map;
+import javaslang.control.Option;
+
+import static org.core.parse.FormUrlencoded.*;
+
+public class FormUrlencoded {
+    private HashMap<String, String> values;
+
+    public FormUrlencoded() {
+        values = HashMap.empty();
+    }
+
+    public FormUrlencoded(String content) {
+        values = PARSER.parse(content);
+    }
+
+    public boolean isEmpty() {
+        return values.isEmpty();
+    }
+
+    public Map<String, String> toMap() {
+        return values;
+    }
+
+    public Option<String> get(String key) {
+        return values.get(key);
+    }
+
+    public void put(String key, String value) {
+        values = values.put(key, value);
+    }
+
+    private String entryToString(Tuple2<String, String> entry) {
+        String str = entry._1;
+        if (entry._2 != null) {
+            str += "=" + entry._2;
+        }
+
+        return str;
+    }
+
+    @Override
+    public String toString() {
+        return values
+            .map(this::entryToString)
+            .intersperse("&")
+            .fold("", String::concat);
+    }
+}

--- a/src/main/java/org/core/OriginForm.java
+++ b/src/main/java/org/core/OriginForm.java
@@ -1,0 +1,35 @@
+package org.core;
+
+public class OriginForm implements RequestTarget {
+    private String path;
+    private String query;
+
+    public OriginForm(String path) {
+        this.path = path;
+    }
+
+    public OriginForm(String path, String query) {
+        this.path = path;
+        this.query = query;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public String getQuery() {
+        return query;
+    }
+
+    @Override
+    public String toString() {
+        String requestTarget = path;
+        if (query != null) {
+            requestTarget += "?" + query;
+        }
+
+        return requestTarget;
+    }
+}

--- a/src/main/java/org/core/Request.java
+++ b/src/main/java/org/core/Request.java
@@ -6,11 +6,11 @@ import javaslang.Tuple;
 
 public class Request {
     private String method;
-    private String requestTarget;
+    private RequestTarget requestTarget;
     private Map<String, String> headers;
     private String body;
 
-    public Request(String method, String requestTarget, Map<String, String> headers, String body) {
+    public Request(String method, RequestTarget requestTarget, Map<String, String> headers, String body) {
         this.method = method;
         this.requestTarget = requestTarget;
         this.headers = headers.map((key, value) -> Tuple.of(key.toLowerCase(), value));
@@ -21,7 +21,7 @@ public class Request {
         return method;
     }
 
-    public String getRequestTarget() {
+    public RequestTarget getRequestTarget() {
         return requestTarget;
     }
 

--- a/src/main/java/org/core/RequestTarget.java
+++ b/src/main/java/org/core/RequestTarget.java
@@ -1,0 +1,6 @@
+package org.core;
+
+public interface RequestTarget {
+    public String getPath();
+    public String getQuery();
+}

--- a/src/main/java/org/core/Server.java
+++ b/src/main/java/org/core/Server.java
@@ -42,7 +42,7 @@ public class Server {
     }
 
     private boolean isUriMatch(Route route, Request request) {
-        return Match(route.getUriTemplate().match(request.getRequestTarget())).of(
+        return Match(route.getUriTemplate().match(request.getRequestTarget().getPath())).of(
             Case(Some($()), true),
             Case(None(), false)
         );

--- a/src/main/java/org/core/parse/Cookie.java
+++ b/src/main/java/org/core/parse/Cookie.java
@@ -1,0 +1,46 @@
+package org.core.parse;
+
+import javaslang.collection.List;
+import javaslang.collection.HashMap;
+import javaslang.Tuple;
+import javaslang.Tuple2;
+
+import org.jparsec.pattern.Patterns;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
+import org.jparsec.Scanners;
+
+import static org.core.parse.Abnf.*;
+import static org.core.parse.Http.*;
+
+// RFC 6265 - https://tools.ietf.org/html/rfc6265
+public class Cookie {
+    private static final Parser<String> COOKIE_NAME = token;
+    private static final Parser<String> COOKIE_OCTET = Patterns.regex("[\\x21\\x23-\\x2B\\x2D-\\x3A\\x3C-\\x5B\\x5D-\\x7E]").toScanner("cookie-octet").source();
+    private static final Parser<String> COOKIE_VALUE = Parsers.or(
+            COOKIE_OCTET.many().source(),
+            Parsers.sequence(
+                DQUOTE.toScanner("DQUOTE"),
+                COOKIE_OCTET.many().source(),
+                DQUOTE.toScanner("DQUOTE"),
+                (_1, value, _2) -> value
+            )
+        );
+    private static final Parser<Tuple2<String, String>> COOKIE_PAIR = Parsers.sequence(
+            COOKIE_NAME,
+            Scanners.string("="),
+            COOKIE_VALUE,
+            (cookieName, _2, cookieValue) -> Tuple.of(cookieName, cookieValue)
+        );
+    private static final Parser<List<Tuple2<String, String>>> COOKIE_STRING = Parsers.sequence(
+            COOKIE_PAIR,
+            Parsers.sequence(
+                Scanners.string(";"),
+                SP.toScanner("SP"),
+                COOKIE_PAIR,
+                (_1, _2, cookiePair) -> cookiePair
+            ).many().map(List::ofAll),
+            (head, tail) -> tail.prepend(head)
+        );
+    public static final Parser<HashMap<String, String>> PARSER = COOKIE_STRING.map(HashMap::ofEntries);
+}

--- a/src/main/java/org/core/parse/FormUrlencoded.java
+++ b/src/main/java/org/core/parse/FormUrlencoded.java
@@ -12,16 +12,17 @@ import org.jparsec.Scanners;
 
 import static org.core.parse.Abnf.*;
 
+// https://tools.ietf.org/html/draft-hoehrmann-urlencoded-01
 public class FormUrlencoded {
-    public static final Parser<String> PLUS = Scanners.string("+").source();
-    public static final Parser<String> PERCENT = Scanners.string("%").source();
-    public static final Parser<String> SEPERATOR = Scanners.among(";&", "seperator").source();
-    public static final Parser<String> ESCAPE = Patterns.sequence(Patterns.string("%"), HEXDIG, HEXDIG).toScanner("escape").source();
-    public static final Parser<String> NAMECHAR = Scanners.notAmong(";&+%=", "namechar").source();
-    public static final Parser<String> VALUECHAR = Scanners.notAmong(";&+%", "valuechar").source();
-    public static final Parser<String> NAME = Parsers.or(NAMECHAR, ESCAPE, PERCENT, PLUS).many1().source();
-    public static final Parser<String> VALUE = Parsers.or(VALUECHAR, ESCAPE, PERCENT, PLUS).many().source();
-    public static final Parser<Tuple2<String, String>> PAIR = Parsers.sequence(
+    private static final Parser<String> PLUS = Scanners.string("+").source();
+    private static final Parser<String> PERCENT = Scanners.string("%").source();
+    private static final Parser<String> SEPERATOR = Scanners.among(";&", "seperator").source();
+    private static final Parser<String> ESCAPE = Patterns.sequence(Patterns.string("%"), HEXDIG, HEXDIG).toScanner("escape").source();
+    private static final Parser<String> NAMECHAR = Scanners.notAmong(";&+%=", "namechar").source();
+    private static final Parser<String> VALUECHAR = Scanners.notAmong(";&+%", "valuechar").source();
+    private static final Parser<String> NAME = Parsers.or(NAMECHAR, ESCAPE, PERCENT, PLUS).many1().source();
+    private static final Parser<String> VALUE = Parsers.or(VALUECHAR, ESCAPE, PERCENT, PLUS).many().source();
+    private static final Parser<Tuple2<String, String>> PAIR = Parsers.sequence(
             NAME,
             Parsers.sequence(
                 Scanners.string("="),
@@ -30,7 +31,7 @@ public class FormUrlencoded {
             ).optional(),
             Tuple::of
         );
-    public static final Parser<List<Tuple2<String, String>>> PAIRS = Parsers.sequence(
+    private static final Parser<List<Tuple2<String, String>>> PAIRS = Parsers.sequence(
             PAIR,
             Parsers.sequence(
                 SEPERATOR,
@@ -39,6 +40,6 @@ public class FormUrlencoded {
             ).many().map(List::ofAll),
             (head, tail) -> tail.prepend(head)
         );
-    public static final Parser<List<Tuple2<String, String>>> EMPTY_SET = Scanners.string("").retn(List.empty());
+    private static final Parser<List<Tuple2<String, String>>> EMPTY_SET = Scanners.string("").retn(List.empty());
     public static final Parser<HashMap<String, String>> PARSER = Parsers.or(PAIRS, EMPTY_SET).map(HashMap::ofEntries);
 }

--- a/src/main/java/org/core/parse/FormUrlencoded.java
+++ b/src/main/java/org/core/parse/FormUrlencoded.java
@@ -1,0 +1,44 @@
+package org.core.parse;
+
+import javaslang.collection.List;
+import javaslang.collection.HashMap;
+import javaslang.Tuple;
+import javaslang.Tuple2;
+
+import org.jparsec.pattern.Patterns;
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
+import org.jparsec.Scanners;
+
+import static org.core.parse.Abnf.*;
+
+public class FormUrlencoded {
+    public static final Parser<String> PLUS = Scanners.string("+").source();
+    public static final Parser<String> PERCENT = Scanners.string("%").source();
+    public static final Parser<String> SEPERATOR = Scanners.among(";&", "seperator").source();
+    public static final Parser<String> ESCAPE = Patterns.sequence(Patterns.string("%"), HEXDIG, HEXDIG).toScanner("escape").source();
+    public static final Parser<String> NAMECHAR = Scanners.notAmong(";&+%=", "namechar").source();
+    public static final Parser<String> VALUECHAR = Scanners.notAmong(";&+%", "valuechar").source();
+    public static final Parser<String> NAME = Parsers.or(NAMECHAR, ESCAPE, PERCENT, PLUS).many1().source();
+    public static final Parser<String> VALUE = Parsers.or(VALUECHAR, ESCAPE, PERCENT, PLUS).many().source();
+    public static final Parser<Tuple2<String, String>> PAIR = Parsers.sequence(
+            NAME,
+            Parsers.sequence(
+                Scanners.string("="),
+                VALUE,
+                (_1, value) -> value
+            ).optional(),
+            Tuple::of
+        );
+    public static final Parser<List<Tuple2<String, String>>> PAIRS = Parsers.sequence(
+            PAIR,
+            Parsers.sequence(
+                SEPERATOR,
+                PAIR,
+                (_1, pair) -> pair
+            ).many().map(List::ofAll),
+            (head, tail) -> tail.prepend(head)
+        );
+    public static final Parser<List<Tuple2<String, String>>> EMPTY_SET = Scanners.string("").retn(List.empty());
+    public static final Parser<HashMap<String, String>> PARSER = Parsers.or(PAIRS, EMPTY_SET).map(HashMap::ofEntries);
+}

--- a/src/main/java/org/httpserver/HttpServer.java
+++ b/src/main/java/org/httpserver/HttpServer.java
@@ -5,13 +5,15 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.Path;
 
-import org.httpserver.controller.FileSystemController;
+import javaslang.collection.Map;
+
 import org.core.Application;
 import org.core.Response;
 import org.core.Request;
 import org.core.StatusCode;
 
-import javaslang.collection.Map;
+import org.httpserver.controller.CookieController;
+import org.httpserver.controller.FileSystemController;
 
 class HttpServer {
     public static void main(String[] args) throws IOException {
@@ -54,25 +56,21 @@ class HttpServer {
         });
 
         app.get("/method_options", fileSystemController::get);
+        app.post("/method_options", (request) -> Response.create());
         app.put("/method_options", fileSystemController::write);
-
         app.options("/method_options", (request) -> {
             Response response = Response.create();
             response.setHeader("Allow", "GET,HEAD,POST,OPTIONS,PUT");
             return response;
         });
 
-        app.post("/method_options", (request) -> {
-            return Response.create();
-        });
+        app.get("/method_options2", (request) -> Response.create());
 
         app.options("/method_options2", (request) -> {
             Response response = Response.create();
             response.setHeader("Allow", "GET,OPTIONS");
             return response;
         });
-
-        app.get("/method_options2", fileSystemController::get);
 
         app.get("/logs", (request) -> {
             String auth = request.getHeader("Authorization").getOrElse("");
@@ -93,6 +91,10 @@ class HttpServer {
 
             return response;
         });
+
+        CookieController cookieController = new CookieController();
+        app.get("/cookie", cookieController::writeCookie);
+        app.get("/eat_cookie", cookieController::useCookie);
 
         app.run(port);
     }

--- a/src/main/java/org/httpserver/controller/CookieController.java
+++ b/src/main/java/org/httpserver/controller/CookieController.java
@@ -1,0 +1,55 @@
+package org.httpserver.controller;
+
+import static javaslang.API.*;
+import static javaslang.Patterns.*;
+
+import org.core.Cookie;
+import org.core.FormUrlencoded;
+import org.core.Request;
+import org.core.Response;
+
+public class CookieController {
+    public Response writeCookie(Request request) {
+        FormUrlencoded query = getQuery(request);
+
+        Response response = Match(query.get("type")).of(
+            Case(Some($()), (type) -> {
+                Response r= Response.create();
+                Cookie cookie = getCookie(request);
+                cookie.put("type", type);
+                r.setHeader("Set-Cookie", cookie.toString());
+                return r;
+            }),
+            Case(None(), () -> Response.create())
+        );
+
+        response.setBody("Eat");
+
+        return response;
+    }
+
+    public Response useCookie(Request request) {
+        Response response = Response.create();
+        Cookie cookie = getCookie(request);
+        response.setBody("mmmm " + cookie.get("type").getOrElse("don't you wish you had a cookie?"));
+
+        return response;
+    }
+
+    private FormUrlencoded getQuery(Request request) {
+        String query = request.getRequestTarget().getQuery();
+
+        if (query != null) {
+            return new FormUrlencoded(query);
+        } else {
+            return new FormUrlencoded();
+        }
+    }
+
+    private Cookie getCookie(Request request) {
+        return Match(request.getHeader("Cookie")).of(
+            Case(Some($()), (content) -> new Cookie(content)),
+            Case(None(), () -> new Cookie())
+        );
+    }
+}

--- a/src/main/java/org/httpserver/controller/FileSystemController.java
+++ b/src/main/java/org/httpserver/controller/FileSystemController.java
@@ -28,12 +28,12 @@ public class FileSystemController {
     }
 
     public Response get(Request request) {
-        Path targetPath = rootPath.resolve("." + request.getRequestTarget()).normalize();
+        Path targetPath = rootPath.resolve("." + request.getRequestTarget().getPath()).normalize();
 
         try {
             if (Files.exists(targetPath)) {
                 Response response = Response.create();
-                String extension = FileSystem.getExtension(request.getRequestTarget());
+                String extension = FileSystem.getExtension(request.getRequestTarget().getPath());
                 String contentType = MediaType.fromExtension(extension).getOrElse("application/octet-stream");
                 response.setHeader("Content-Type", contentType);
                 response.setBody(Files.newInputStream(targetPath));
@@ -49,7 +49,7 @@ public class FileSystemController {
 
     public Response index(Request request) {
         try {
-            Path targetPath = rootPath.resolve("." + request.getRequestTarget()).normalize();
+            Path targetPath = rootPath.resolve("." + request.getRequestTarget().getPath()).normalize();
             List<Link> links = List.ofAll(Files.walk(targetPath)
                 .filter(Files::isRegularFile)
                 .map((filePath) -> {
@@ -58,7 +58,7 @@ public class FileSystemController {
                     return new Link(href, display);
                 })
                 .collect(Collectors.toList()));
-            Index index = new Index(request.getRequestTarget(), links);
+            Index index = new Index(request.getRequestTarget().getPath(), links);
 
             Response response = Response.create();
             response.setHeader("Content-Type", "text/html; charset=utf-8");
@@ -71,7 +71,7 @@ public class FileSystemController {
     }
 
     public Response delete(Request request) {
-        Path targetPath = rootPath.resolve("." + request.getRequestTarget()).normalize();
+        Path targetPath = rootPath.resolve("." + request.getRequestTarget().getPath()).normalize();
 
         try {
             Files.delete(targetPath);
@@ -83,7 +83,7 @@ public class FileSystemController {
 
     public Response write(Request request) {
         ByteArrayInputStream body = new ByteArrayInputStream(request.getBody().getBytes());
-        return _write(request.getRequestTarget(), body);
+        return _write(request.getRequestTarget().getPath(), body);
     }
 
     public Response write(Request request, String location) {

--- a/src/test/java/org/core/ApplicationTest.java
+++ b/src/test/java/org/core/ApplicationTest.java
@@ -28,7 +28,28 @@ public class ApplicationTest {
 
         Server server = app.getServer();
 
-        Request request = new Request("GET", "/foo", HashMap.empty(), "");
+        Request request = new Request("GET", new OriginForm("/foo"), HashMap.empty(), "");
+        Response response = server.handle(request);
+
+        assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
+        assertThat(response.getHeader("Content-Length"), equalTo(Option.of("3")));
+        assertThat(response.getBodyAsString(), equalTo("foo"));
+    }
+
+    @Test
+    public void itShouldMatchRoutesWithoutQueryParams() {
+        Application app = new Application();
+
+        app.get("/foo", (request) -> {
+            Response response = Response.create();
+            response.setBody("foo");
+
+            return response;
+        });
+
+        Server server = app.getServer();
+
+        Request request = new Request("GET", new OriginForm("/foo", "bar"), HashMap.empty(), "");
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
@@ -49,7 +70,7 @@ public class ApplicationTest {
 
         Server server = app.getServer();
 
-        Request request = new Request("HEAD", "/foo", HashMap.empty(), "");
+        Request request = new Request("HEAD", new OriginForm("/foo"), HashMap.empty(), "");
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
@@ -70,7 +91,7 @@ public class ApplicationTest {
 
         Server server = app.getServer();
 
-        Request request = new Request("POST", "/foo", HashMap.empty(), "");
+        Request request = new Request("POST", new OriginForm("/foo"), HashMap.empty(), "");
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
@@ -91,7 +112,7 @@ public class ApplicationTest {
 
         Server server = app.getServer();
 
-        Request request = new Request("PUT", "/foo", HashMap.empty(), "");
+        Request request = new Request("PUT", new OriginForm("/foo"), HashMap.empty(), "");
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
@@ -112,7 +133,7 @@ public class ApplicationTest {
 
         Server server = app.getServer();
 
-        Request request = new Request("DELETE", "/foo", HashMap.empty(), "");
+        Request request = new Request("DELETE", new OriginForm("/foo"), HashMap.empty(), "");
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
@@ -134,7 +155,7 @@ public class ApplicationTest {
 
         Server server = app.getServer();
 
-        Request request = new Request("OPTIONS", "/foo", HashMap.empty(), "");
+        Request request = new Request("OPTIONS", new OriginForm("/foo"), HashMap.empty(), "");
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
@@ -156,7 +177,7 @@ public class ApplicationTest {
 
         Server server = app.getServer();
 
-        Request request = new Request("PATCH", "/foo", HashMap.empty(), "");
+        Request request = new Request("PATCH", new OriginForm("/foo"), HashMap.empty(), "");
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.NO_CONTENT));
@@ -171,7 +192,7 @@ public class ApplicationTest {
 
         Server server = app.getServer();
 
-        Request request = new Request("GET", "/foo", HashMap.empty(), "");
+        Request request = new Request("GET", new OriginForm("/foo"), HashMap.empty(), "");
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.NOT_FOUND));
@@ -184,7 +205,7 @@ public class ApplicationTest {
 
         Server server = app.getServer();
 
-        Request request = new Request("HEAD", "/foo", HashMap.empty(), "");
+        Request request = new Request("HEAD", new OriginForm("/foo"), HashMap.empty(), "");
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.NOT_FOUND));
@@ -205,7 +226,7 @@ public class ApplicationTest {
 
         Server server = app.getServer();
 
-        Request request = new Request("GET", "/foo", HashMap.empty(), "");
+        Request request = new Request("GET", new OriginForm("/foo"), HashMap.empty(), "");
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.METHOD_NOT_ALLOWED));
@@ -230,7 +251,7 @@ public class ApplicationTest {
 
         Server server = app.getServer();
 
-        Request request = new Request("DELETE", "/foo", HashMap.empty(), "");
+        Request request = new Request("DELETE", new OriginForm("/foo"), HashMap.empty(), "");
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.METHOD_NOT_ALLOWED));

--- a/src/test/java/org/core/CookieTest.java
+++ b/src/test/java/org/core/CookieTest.java
@@ -1,0 +1,58 @@
+package org.core;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+
+import javaslang.control.Option;
+
+@RunWith(DataProviderRunner.class)
+public class CookieTest {
+
+    @Test
+    public void itShouldStartOutEmpty() {
+        Cookie cookie = new Cookie();
+        assertThat(cookie.isEmpty(), equalTo(true));
+    }
+
+    @Test
+    public void itShouldReturnNoneIfGettingAValueThatDoesntExist() {
+        Cookie cookie = new Cookie();
+        assertThat(cookie.get("foo"), equalTo(Option.none()));
+    }
+
+    @Test
+    public void itShouldBeAbleToAddValues() {
+        Cookie cookie = new Cookie();
+        cookie.put("foo", "bar");
+        assertThat(cookie.isEmpty(), equalTo(false));
+        assertThat(cookie.get("foo"), equalTo(Option.of("bar")));
+    }
+
+    @Test
+    public void itShouldContructACookieFromASetCookieHeader() {
+        Cookie cookie = new Cookie("foo=bar");
+        assertThat(cookie.get("foo"), equalTo(Option.of("bar")));
+    }
+
+    @DataProvider
+    public static Object[][] dataProviderCookies() {
+        return new Object[][] {
+            { "foo=bar" },
+            { "abc=123; foo=bar" }
+        };
+    }
+
+    @Test
+    @UseDataProvider("dataProviderCookies")
+    public void itShouldBeSerializableToASetCookieHeader(String subject) {
+        Cookie cookie = new Cookie(subject);
+        assertThat(cookie.toString(), equalTo(subject));
+    }
+
+}

--- a/src/test/java/org/core/FormUrlencodedTest.java
+++ b/src/test/java/org/core/FormUrlencodedTest.java
@@ -1,0 +1,61 @@
+package org.core;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+
+import javaslang.control.Option;
+
+@RunWith(DataProviderRunner.class)
+public class FormUrlencodedTest {
+
+    @Test
+    public void itShouldStartOutEmpty() {
+        FormUrlencoded values = new FormUrlencoded();
+        assertThat(values.isEmpty(), equalTo(true));
+    }
+
+    @Test
+    public void itShouldReturnNoneIfGettingAValueThatDoesntExist() {
+        FormUrlencoded values = new FormUrlencoded();
+        assertThat(values.get("foo"), equalTo(Option.none()));
+    }
+
+    @Test
+    public void itShouldBeAbleToAddValues() {
+        FormUrlencoded values = new FormUrlencoded();
+        values.put("foo", "bar");
+        assertThat(values.isEmpty(), equalTo(false));
+        assertThat(values.get("foo"), equalTo(Option.of("bar")));
+    }
+
+    @Test
+    public void itShouldContructValuesFromAString() {
+        FormUrlencoded values = new FormUrlencoded("foo=bar");
+        assertThat(values.get("foo"), equalTo(Option.of("bar")));
+    }
+
+    @DataProvider
+    public static Object[][] dataProviderEncoded() {
+        return new Object[][] {
+            { "" },
+            { "foo=bar" },
+            { "foo" },
+            { "abc=123&foo=bar" }
+        };
+    }
+
+    @Test
+    @UseDataProvider("dataProviderEncoded")
+    public void itShouldBeSerializableToAString(String subject) {
+        FormUrlencoded values = new FormUrlencoded(subject);
+        assertThat(values.toString(), equalTo(subject));
+    }
+
+}
+

--- a/src/test/java/org/core/OriginFormTest.java
+++ b/src/test/java/org/core/OriginFormTest.java
@@ -1,0 +1,31 @@
+package org.core;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+
+import javaslang.collection.HashMap;
+import javaslang.control.Option;
+import javaslang.Tuple;
+
+@RunWith(DataProviderRunner.class)
+public class OriginFormTest {
+
+    @Test
+    public void itShouldHaveAPathPart() {
+        OriginForm originForm = new OriginForm("/");
+        assertThat(originForm.getPath(), equalTo("/"));
+    }
+
+    @Test
+    public void itShouldHaveAQueryPart() {
+        OriginForm originForm = new OriginForm("/", "foo=bar");
+        assertThat(originForm.getQuery(), equalTo("foo=bar"));
+    }
+
+}

--- a/src/test/java/org/core/RequestTest.java
+++ b/src/test/java/org/core/RequestTest.java
@@ -27,21 +27,22 @@ public class RequestTest {
     @Test
     @UseDataProvider("dataProviderMethods")
     public void itShouldAllowGettingTheMethod(String method) {
-        Request request = new Request(method, "/hello.txt", HashMap.empty(), "foo");
+        Request request = new Request(method, new OriginForm("/hello.txt"), HashMap.empty(), "foo");
         assertThat(request.getMethod(), equalTo(method));
     }
 
     @DataProvider
     public static Object[][] dataProviderRequestTargets() {
         return new Object[][] {
-            { "/" },
-            { "/hello.txt" }
+            { new OriginForm("/") },
+            { new OriginForm("/hello.txt") },
+            { new OriginForm("/hello.txt", "foo=bar") }
         };
     }
 
     @Test
     @UseDataProvider("dataProviderRequestTargets")
-    public void itShouldAllowGettingTheRequestTarget(String requestTarget) {
+    public void itShouldAllowGettingTheRequestTarget(RequestTarget requestTarget) {
         Request request = new Request("GET", requestTarget, HashMap.empty(), "foo");
         assertThat(request.getRequestTarget(), equalTo(requestTarget));
     }
@@ -60,33 +61,33 @@ public class RequestTest {
     @Test
     @UseDataProvider("dataProviderHeaders")
     public void itShouldAllowGettingTheMethod(HashMap<String, String>  headers, Option expected) {
-        Request request = new Request("GET", "/hello.txt", headers, "foo");
+        Request request = new Request("GET", new OriginForm("/hello.txt"), headers, "foo");
         assertThat(request.getHeader("Content-Length"), equalTo(expected));
     }
 
     @Test
     public void itShouldAllowSettingHeaders() {
-        Request request = new Request("GET", "/hello.txt", HashMap.empty(), "foo");
+        Request request = new Request("GET", new OriginForm("/hello.txt"), HashMap.empty(), "foo");
         request.setHeader("Content-Length", "3");
         assertThat(request.getHeader("Content-Length"), equalTo(Option.of("3")));
     }
 
     @Test
     public void matchingHeadersShouldBeCaseInsensitive() {
-        Request request = new Request("GET", "/hello.txt", HashMap.empty(), "foo");
+        Request request = new Request("GET", new OriginForm("/hello.txt"), HashMap.empty(), "foo");
         request.setHeader("Content-Length", "3");
         assertThat(request.getHeader("content-length"), equalTo(Option.of("3")));
     }
 
     @Test
-    public void isShouldAllowGettingTheBody() {
-        Request request = new Request("GET", "/hello.txt", HashMap.empty(), "foo");
+    public void itShouldAllowGettingTheBody() {
+        Request request = new Request("GET", new OriginForm("/hello.txt"), HashMap.empty(), "foo");
         assertThat(request.getBody(), equalTo("foo"));
     }
 
     @Test
-    public void isShouldAllowSettingTheBody() {
-        Request request = new Request("GET", "/hello.txt", HashMap.empty(), "foo");
+    public void itShouldAllowSettingTheBody() {
+        Request request = new Request("GET", new OriginForm("/hello.txt"), HashMap.empty(), "foo");
         request.setBody("bar");
         assertThat(request.getBody(), equalTo("bar"));
     }

--- a/src/test/java/org/core/parse/CookieTest.java
+++ b/src/test/java/org/core/parse/CookieTest.java
@@ -1,0 +1,31 @@
+package org.core.parse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+
+import javaslang.collection.HashMap;
+import javaslang.control.Option;
+
+@RunWith(DataProviderRunner.class)
+public class CookieTest {
+
+    @Test
+    public void itShouldParseASinglePair() {
+        HashMap<String, String> cookies = Cookie.PARSER.parse("foo=bar");
+        assertThat(cookies.get("foo"), equalTo(Option.of("bar")));
+    }
+
+    @Test
+    public void itShouldParseMultiplePairs() {
+        HashMap<String, String> cookies = Cookie.PARSER.parse("foo=bar; abc=123");
+        assertThat(cookies.get("foo"), equalTo(Option.of("bar")));
+        assertThat(cookies.get("abc"), equalTo(Option.of("123")));
+    }
+
+}

--- a/src/test/java/org/core/parse/FormUrlencodedTest.java
+++ b/src/test/java/org/core/parse/FormUrlencodedTest.java
@@ -1,0 +1,43 @@
+package org.core.parse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+
+import javaslang.collection.HashMap;
+import javaslang.control.Option;
+
+@RunWith(DataProviderRunner.class)
+public class FormUrlencodedTest {
+
+    @Test
+    public void itShouldParseAnEmptyString() {
+        HashMap<String, String> content = FormUrlencoded.PARSER.parse("");
+        assertThat(content.isEmpty(), equalTo(true));
+    }
+
+    @Test
+    public void itShouldParseASingleValue() {
+        HashMap<String, String> content = FormUrlencoded.PARSER.parse("foo");
+        assertThat(content.get("foo"), equalTo(Option.some(null)));
+    }
+
+    @Test
+    public void itShouldParseAKeyValuePair() {
+        HashMap<String, String> content = FormUrlencoded.PARSER.parse("foo=bar");
+        assertThat(content.get("foo"), equalTo(Option.of("bar")));
+    }
+
+    @Test
+    public void itShouldParseMultipleKeyValuePairs() {
+        HashMap<String, String> content = FormUrlencoded.PARSER.parse("foo=bar&bar=foo");
+        assertThat(content.get("foo"), equalTo(Option.of("bar")));
+        assertThat(content.get("bar"), equalTo(Option.of("foo")));
+    }
+
+}

--- a/src/test/java/org/core/parse/HttpParserTest.java
+++ b/src/test/java/org/core/parse/HttpParserTest.java
@@ -20,6 +20,7 @@ import javaslang.Tuple;
 import javaslang.Tuple2;
 
 import org.core.Request;
+import org.core.RequestTarget;
 
 @RunWith(DataProviderRunner.class)
 public class HttpParserTest {
@@ -30,7 +31,7 @@ public class HttpParserTest {
 
         assertThat(request, instanceOf(Request.class));
         assertThat(request.getMethod(), equalTo("GET"));
-        assertThat(request.getRequestTarget(), equalTo("/hello.txt"));
+        assertThat(request.getRequestTarget().getPath(), equalTo("/hello.txt"));
     }
 
     @DataProvider
@@ -52,19 +53,22 @@ public class HttpParserTest {
     @DataProvider
     public static Object[][] dataProviderRequestTarget() {
         return new Object[][] {
-            { "/" },
-            { "/hello" },
-            { "/hello.txt" },
-            { "/hello.txt?" },
-            { "/hello.txt?foo" },
-            { "/hello.txt?foo=bar" }
+            { "/", "/", null },
+            { "/hello", "/hello", null },
+            { "/hello.txt", "/hello.txt", null },
+            { "/hello.txt?", "/hello.txt", "" },
+            { "/hello.txt?foo", "/hello.txt", "foo" },
+            { "/hello.txt?foo=bar", "/hello.txt", "foo=bar" },
+            { "/hello.txt?foo=bar&abc=123", "/hello.txt", "foo=bar&abc=123" }
         };
     }
 
     @Test
     @UseDataProvider("dataProviderRequestTarget")
-    public void itShouldParseRequestTarget(String subject) {
-        assertThat(Http.requestTarget.parse(subject), equalTo(subject));
+    public void itShouldParseRequestTarget(String subject, String path, String query) {
+        RequestTarget requestTarget = Http.requestTarget.parse(subject);
+        assertThat(requestTarget.getPath(), equalTo(path));
+        assertThat(requestTarget.getQuery(), equalTo(query));
     }
 
     @DataProvider
@@ -93,7 +97,7 @@ public class HttpParserTest {
         Request request = Http.request(reader);
 
         assertThat(request.getMethod(), equalTo("GET"));
-        assertThat(request.getRequestTarget(), equalTo("/hello.txt"));
+        assertThat(request.getRequestTarget().getPath(), equalTo("/hello.txt"));
         assertThat(request.getHeader("Accept"), equalTo(Option.of("text/plain; charset=utf-8")));
     }
 
@@ -111,7 +115,7 @@ public class HttpParserTest {
         Request request = Http.request(reader);
 
         assertThat(request.getMethod(), equalTo("POST"));
-        assertThat(request.getRequestTarget(), equalTo("/form"));
+        assertThat(request.getRequestTarget().getPath(), equalTo("/form"));
         assertThat(request.getHeader("Content-Length"), equalTo(Option.of("20")));
         assertThat(request.getHeader("Content-Type"), equalTo(Option.of("application/json")));
         assertThat(request.getBody(), equalTo("{ \"hello\": \"world\" }"));

--- a/src/test/java/org/httpserver/controller/CookieControllerTest.java
+++ b/src/test/java/org/httpserver/controller/CookieControllerTest.java
@@ -1,0 +1,78 @@
+package org.httpserver.controller;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.Test;
+import org.junit.After;
+import org.junit.runner.RunWith;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+
+import javaslang.control.Option;
+import javaslang.collection.HashMap;
+
+import org.core.OriginForm;
+import org.core.Response;
+import org.core.Request;
+import org.core.StatusCode;
+
+@RunWith(DataProviderRunner.class)
+public class CookieControllerTest {
+
+    @Test
+    public void itShouldSetACookie() {
+        CookieController controller = new CookieController();
+        Request request = new Request("GET", new OriginForm("/cookie", "type=chocolate"), HashMap.empty(), "");
+        Response response = controller.writeCookie(request);
+
+        assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
+        assertThat(response.getHeader("Set-Cookie"), equalTo(Option.of("type=chocolate")));
+        assertThat(response.getBodyAsString(), containsString("Eat"));
+    }
+
+    @Test
+    public void itShouldNotSetACookieIfThereIsNoTypeQueryParam() {
+        CookieController controller = new CookieController();
+        Request request = new Request("GET", new OriginForm("/cookie"), HashMap.empty(), "");
+        Response response = controller.writeCookie(request);
+
+        assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
+        assertThat(response.getHeader("Set-Cookie"), equalTo(Option.none()));
+        assertThat(response.getBodyAsString(), containsString("Eat"));
+    }
+
+    @Test
+    public void itShouldUseACookie() {
+        CookieController controller = new CookieController();
+        Request request = new Request("GET", new OriginForm("/eat_cookie"), HashMap.empty(), "");
+        request.setHeader("Cookie", "type=chocolate");
+        Response response = controller.useCookie(request);
+
+        assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
+        assertThat(response.getBodyAsString(), containsString("mmmm chocolate"));
+    }
+
+    @Test
+    public void itShouldUseDefaultIfThereIsNoTypeCookie() {
+        CookieController controller = new CookieController();
+        Request request = new Request("GET", new OriginForm("/eat_cookie"), HashMap.empty(), "");
+        request.setHeader("Cookie", "foo=bar");
+        Response response = controller.useCookie(request);
+
+        assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
+        assertThat(response.getBodyAsString(), equalTo("mmmm don't you wish you had a cookie?"));
+    }
+
+    @Test
+    public void itShouldUseDefaultIfThereIsNoCookieAtAll() {
+        CookieController controller = new CookieController();
+        Request request = new Request("GET", new OriginForm("/eat_cookie"), HashMap.empty(), "");
+        Response response = controller.useCookie(request);
+
+        assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
+        assertThat(response.getBodyAsString(), equalTo("mmmm don't you wish you had a cookie?"));
+    }
+
+}

--- a/src/test/java/org/httpserver/controller/FileSystemControllerTest.java
+++ b/src/test/java/org/httpserver/controller/FileSystemControllerTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Paths;
 import javaslang.collection.HashMap;
 import javaslang.control.Option;
 
+import org.core.OriginForm;
 import org.core.Response;
 import org.core.Request;
 import org.core.StatusCode;
@@ -27,7 +28,7 @@ public class FileSystemControllerTest {
     @Test
     public void itShouldGetAFileFromTheFileSystem() {
         FileSystemController controller = new FileSystemController(Paths.get("public"));
-        Request request = new Request("GET", "/file1", HashMap.empty(), "");
+        Request request = new Request("GET", new OriginForm("/file1"), HashMap.empty(), "");
         Response response = controller.get(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
@@ -38,7 +39,7 @@ public class FileSystemControllerTest {
     @Test
     public void itShould404WhenGettingANonexistentFileFromTheFileSystem() {
         FileSystemController controller = new FileSystemController(Paths.get("public"));
-        Request request = new Request("GET", "/foobar", HashMap.empty(), "");
+        Request request = new Request("GET", new OriginForm("/foobar"), HashMap.empty(), "");
         Response response = controller.get(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.NOT_FOUND));
@@ -47,7 +48,7 @@ public class FileSystemControllerTest {
     @Test
     public void itShouldGetADirectoryListingFromTheFileSystem() {
         FileSystemController controller = new FileSystemController(Paths.get("public"));
-        Request request = new Request("GET", "/", HashMap.empty(), "");
+        Request request = new Request("GET", new OriginForm("/"), HashMap.empty(), "");
         Response response = controller.index(request);
         String body = response.getBodyAsString();
 
@@ -62,7 +63,7 @@ public class FileSystemControllerTest {
         Files.copy(Paths.get("public/file1"), Paths.get("public/foo"));
 
         FileSystemController controller = new FileSystemController(Paths.get("public"));
-        Request request = new Request("DELETE", "/foo", HashMap.empty(), "");
+        Request request = new Request("DELETE", new OriginForm("/foo"), HashMap.empty(), "");
         Response response = controller.delete(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
@@ -71,7 +72,7 @@ public class FileSystemControllerTest {
     @Test
     public void itShouldPutANewFileToTheFileSystem() throws IOException {
         FileSystemController controller = new FileSystemController(Paths.get("public"));
-        Request request = new Request("PUT", "/foo", HashMap.empty(), "foo contents");
+        Request request = new Request("PUT", new OriginForm("/foo"), HashMap.empty(), "foo contents");
         Response response = controller.write(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.CREATED));
@@ -83,7 +84,7 @@ public class FileSystemControllerTest {
         Files.copy(Paths.get("public/file1"), Paths.get("public/foo"));
 
         FileSystemController controller = new FileSystemController(Paths.get("public"));
-        Request request = new Request("PUT", "/foo", HashMap.empty(), "foo contents");
+        Request request = new Request("PUT", new OriginForm("/foo"), HashMap.empty(), "foo contents");
         Response response = controller.write(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));


### PR DESCRIPTION
This required quite a few changes.  I wrote parsers for application/x-www-form-urlencoded data and cookie data.  Cookie support is still minimal, but there is enough to handle the simple tests we have.  I also had to refactor route matching to not take the query params into account.