### PR TITLE
Partial content

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ String fooCookie = cookie
 |  X  |     |     |  1  | Convert StatusCode tests to parameterized tests
 |     |  X  |     |  1  | Audit the code for `*` imports and clean up where necessary.
 |     |  X  |     |  1  | Audit the code for unused imports and clean up where necessary.
-|     |  X  |     |  5  | Singe range partial content support.  It should ignore ranges it doesn't understand.  It should pass the ResponseTestSuite.PartialContent cob_spec test.
+|     |     |  X  |  5  | Singe range partial content support.  It should ignore ranges it doesn't understand.  It should pass the ResponseTestSuite.PartialContent cob_spec test.
 |  X  |     |     |  2  | Decode URL encoded characters.  It should pass the ResponseTestSuite.ParameterDecode cob_spec test.
 
 **Legend:** *AV* => Available, *IP* => In Progress, *CP* => Completed, *SP* => Story Points

--- a/src/main/java/org/cobspec/controller/FileSystemController.java
+++ b/src/main/java/org/cobspec/controller/FileSystemController.java
@@ -37,9 +37,7 @@ public class FileSystemController {
     public Response get(Request request) throws IOException {
         Path targetPath = getTargetPath(request);
 
-        if (!Files.exists(targetPath)) {
-            throw new NotFoundHttpException();
-        }
+        ensureFileExists(targetPath);
 
         Response response = Response.create();
         String extension = FileSystem.getExtension(request.getRequestTarget().getPath());
@@ -53,9 +51,7 @@ public class FileSystemController {
     public Response index(Request request) throws IOException {
         Path targetPath = getTargetPath(request);
 
-        if (!Files.exists(targetPath)) {
-            throw new NotFoundHttpException();
-        }
+        ensureFileExists(targetPath);
 
         List<Link> links = List.ofAll(Files.walk(targetPath)
             .filter(Files::isRegularFile)
@@ -95,9 +91,7 @@ public class FileSystemController {
     public Response patch(Request request) throws IOException, InterruptedException {
         Path targetPath = getTargetPath(request);
 
-        if (!Files.exists(targetPath)) {
-            throw new NotFoundHttpException();
-        }
+        ensureFileExists(targetPath);
 
         if (!isPatchTypeSupported(request.getHeader("Content-Type"))) {
             HttpException he = new UnsupportedMediaTypeHttpException();
@@ -117,6 +111,12 @@ public class FileSystemController {
             return response;
         } else {
             return Response.create(StatusCode.NO_CONTENT);
+        }
+    }
+
+    private void ensureFileExists(Path targetPath) {
+        if (!Files.exists(targetPath)) {
+            throw new NotFoundHttpException();
         }
     }
 

--- a/src/main/java/org/flint/Response.java
+++ b/src/main/java/org/flint/Response.java
@@ -74,6 +74,12 @@ public class Response {
         this.headers = headers.put(header, value);
     }
 
+    public int getContentLength() {
+        return getHeader("Content-Length")
+            .map(Integer::parseInt)
+            .get();
+    }
+
     public void setBody(String body) {
         setBody(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
     }

--- a/src/main/java/org/flint/Server.java
+++ b/src/main/java/org/flint/Server.java
@@ -5,6 +5,7 @@ import static javaslang.API.*;
 import static javaslang.Patterns.*;
 
 import org.flint.exception.HttpException;
+import org.flint.range.RangeMiddleware;
 
 public class Server {
     List<Route> routes;
@@ -28,6 +29,8 @@ public class Server {
             } else {
                 try {
                     response = methodMatches.head().getController().apply(request);
+                    RangeMiddleware range = new RangeMiddleware();
+                    response = range.apply(request, response);
                 } catch (HttpException he) {
                     response = defaultResponse(he.getStatusCode());
                     he.getHeaders().forEach(response::setHeader);

--- a/src/main/java/org/flint/exception/HttpException.java
+++ b/src/main/java/org/flint/exception/HttpException.java
@@ -39,6 +39,13 @@ public class HttpException extends RuntimeException {
         this.headers = HashMap.empty();
     }
 
+    public HttpException(int statusCode, Throwable cause) {
+        super(cause);
+
+        this.statusCode = statusCode;
+        this.headers = HashMap.empty();
+    }
+
     public int getStatusCode() {
         return statusCode;
     }

--- a/src/main/java/org/flint/exception/NotFoundHttpException.java
+++ b/src/main/java/org/flint/exception/NotFoundHttpException.java
@@ -18,4 +18,8 @@ public class NotFoundHttpException extends HttpException {
     public NotFoundHttpException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
         super(StatusCode.NOT_FOUND, message, cause, enableSuppression, writableStackTrace);
     }
+
+    public NotFoundHttpException(Throwable cause) {
+        super(StatusCode.NOT_FOUND, cause);
+    }
 }

--- a/src/main/java/org/flint/exception/PreconditionFailedHttpException.java
+++ b/src/main/java/org/flint/exception/PreconditionFailedHttpException.java
@@ -18,4 +18,8 @@ public class PreconditionFailedHttpException extends HttpException {
     public PreconditionFailedHttpException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
         super(StatusCode.PRECONDITION_FAILED, message, cause, enableSuppression, writableStackTrace);
     }
+
+    public PreconditionFailedHttpException(Throwable cause) {
+        super(StatusCode.PRECONDITION_FAILED, cause);
+    }
 }

--- a/src/main/java/org/flint/exception/UnauthorizedHttpException.java
+++ b/src/main/java/org/flint/exception/UnauthorizedHttpException.java
@@ -26,4 +26,10 @@ public class UnauthorizedHttpException extends HttpException {
 
         setHeader("WWW-Authenticate", challenge);
     }
+
+    public UnauthorizedHttpException(String challenge, Throwable cause) {
+        super(StatusCode.UNAUTHORIZED, cause);
+
+        setHeader("WWW-Authenticate", challenge);
+    }
 }

--- a/src/main/java/org/flint/exception/UnsupportedMediaTypeHttpException.java
+++ b/src/main/java/org/flint/exception/UnsupportedMediaTypeHttpException.java
@@ -18,5 +18,8 @@ public class UnsupportedMediaTypeHttpException extends HttpException {
     public UnsupportedMediaTypeHttpException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
         super(StatusCode.UNSUPPORTED_MEDIA_TYPE, message, cause, enableSuppression, writableStackTrace);
     }
-}
 
+    public UnsupportedMediaTypeHttpException(Throwable cause) {
+        super(StatusCode.UNSUPPORTED_MEDIA_TYPE, cause);
+    }
+}

--- a/src/main/java/org/flint/parse/RangeRequests.java
+++ b/src/main/java/org/flint/parse/RangeRequests.java
@@ -1,0 +1,67 @@
+package org.flint.parse;
+
+import javaslang.collection.List;
+import javaslang.Function1;
+import javaslang.Tuple;
+import javaslang.Tuple2;
+
+import org.jparsec.Parser;
+import org.jparsec.Parsers;
+import org.jparsec.Scanners;
+
+import static org.flint.parse.Http.OWS;
+import static org.flint.parse.Abnf.DIGIT;
+import org.flint.range.ByteRange;
+import org.flint.range.Range;
+import org.flint.range.SingleByteRange;
+import org.flint.range.StandardByteRange;
+import org.flint.range.SuffixByteRange;
+
+public class RangeRequests {
+    public static final Parser<String> BYTES_UNIT = Scanners.string("bytes").source();
+    public static final Parser<Integer> FIRST_BYTE_POS = DIGIT.many1().toScanner("first-byte-pos")
+        .source()
+        .map(Integer::parseInt);
+    public static final Parser<Integer> LAST_BYTE_POS = DIGIT.many1().toScanner("last-byte-pos")
+        .source()
+        .map(Integer::parseInt);
+    public static final Parser<StandardByteRange> BYTE_RANGE_SPEC = Parsers.sequence(
+            FIRST_BYTE_POS,
+            Scanners.isChar('-'),
+            LAST_BYTE_POS.optional(),
+            (from, _2, to) -> to == null ? new StandardByteRange(from) : new StandardByteRange(from, to)
+        ).label("byte-range-spec");
+    public static final Parser<Integer> SUFFIX_LENGTH = DIGIT.many1().toScanner("suffix-length")
+        .source()
+        .map(Integer::parseInt);
+    public static final Parser<SuffixByteRange> SUFFIX_BYTE_RANGE_SPEC = Parsers.sequence(
+            Scanners.isChar('-'),
+            SUFFIX_LENGTH,
+            (_1, length) -> new SuffixByteRange(length)
+        ).label("suffix-byte-range-spec");
+    public static final Parser<List<SingleByteRange>> BYTE_RANGE_SET = Parsers.sequence(
+            Parsers.sequence(Scanners.isChar(','), OWS).many(),
+            Parsers.or(BYTE_RANGE_SPEC, SUFFIX_BYTE_RANGE_SPEC),
+            Parsers.sequence(
+                OWS,
+                Scanners.isChar(','),
+                Parsers.sequence(
+                    OWS,
+                    Parsers.or(BYTE_RANGE_SPEC, SUFFIX_BYTE_RANGE_SPEC),
+                    (_1, range) -> range
+                ).optional()
+            ).many().map(List::ofAll),
+            (_1, head, tail) -> tail.prepend(head)
+        ).label("byte-range-set");
+    public static final Parser<ByteRange> BYTE_RANGES_SPECIFIER = Parsers.sequence(
+            BYTES_UNIT,
+            Scanners.isChar('='),
+            BYTE_RANGE_SET,
+            (_1, _2, byteRangeSet) -> Range.createByteRange(byteRangeSet)
+        ).label("byte-ranges-specifier");
+    public static final Parser<Range> OTHER_RANGES_SPECIFIER = Parsers.never(); // Not supported
+    public static final Parser<Range> RANGE = Parsers.or(
+            BYTE_RANGES_SPECIFIER,
+            OTHER_RANGES_SPECIFIER
+        ).label("range");
+}

--- a/src/main/java/org/flint/range/ByteRange.java
+++ b/src/main/java/org/flint/range/ByteRange.java
@@ -1,0 +1,4 @@
+package org.flint.range;
+
+public abstract class ByteRange extends Range {
+}

--- a/src/main/java/org/flint/range/Range.java
+++ b/src/main/java/org/flint/range/Range.java
@@ -1,0 +1,22 @@
+package org.flint.range;
+
+import java.io.IOException;
+
+import javaslang.collection.List;
+
+import org.flint.parse.RangeRequests;
+import org.flint.Response;
+
+public abstract class Range {
+    public abstract Response makePartial(Response response) throws IOException;
+    protected abstract String getPartialContent(Response response) throws IOException;
+    protected abstract String getContentRangeHeader(Response response);
+
+    public static ByteRange createByteRange(List<SingleByteRange> ranges) {
+        return ranges.head();
+    }
+
+    public static Range fromHeader(String header) {
+        return RangeRequests.RANGE.parse(header);
+    }
+}

--- a/src/main/java/org/flint/range/RangeMiddleware.java
+++ b/src/main/java/org/flint/range/RangeMiddleware.java
@@ -1,0 +1,25 @@
+package org.flint.range;
+
+import java.io.IOException;
+
+import javaslang.CheckedFunction2;
+import javaslang.control.Option;
+import javaslang.control.Try;
+
+import org.jparsec.error.ParserException;
+
+import org.flint.Request;
+import org.flint.Response;
+import org.flint.StatusCode;
+
+public class RangeMiddleware implements CheckedFunction2<Request, Response, Response> {
+    public Response apply(Request request, Response response) {
+        return Option.of(request)
+            .filter((r) -> r.getMethod().equals("GET") && response.getStatusCode() == StatusCode.OK)
+            .flatMap((r) -> r.getHeader("Range"))
+            .toTry()
+            .flatMap((range) -> Try.of(() -> Range.fromHeader(range)))
+            .flatMap((range) -> Try.of(() -> range.makePartial(response)))
+            .getOrElse(response);
+    }
+}

--- a/src/main/java/org/flint/range/SingleByteRange.java
+++ b/src/main/java/org/flint/range/SingleByteRange.java
@@ -1,0 +1,18 @@
+package org.flint.range;
+
+import java.io.IOException;
+
+import org.flint.Response;
+import org.flint.StatusCode;
+
+public abstract class SingleByteRange extends ByteRange {
+    @Override
+    public Response makePartial(Response response) throws IOException {
+        String partialContent = getPartialContent(response);
+        response.setStatusCode(StatusCode.PARTIAL_CONTENT);
+        response.setHeader("Content-Range", getContentRangeHeader(response));
+        response.setBody(partialContent);
+
+        return response;
+    }
+}

--- a/src/main/java/org/flint/range/StandardByteRange.java
+++ b/src/main/java/org/flint/range/StandardByteRange.java
@@ -1,0 +1,46 @@
+package org.flint.range;
+
+import java.io.InputStream;
+import java.io.IOException;
+
+import javaslang.control.Option;
+
+import org.flint.Response;
+import org.flint.StatusCode;
+
+public class StandardByteRange extends SingleByteRange {
+    private int from;
+    private Option<Integer> to;
+
+    public StandardByteRange(int from, int to) {
+        this.from = from;
+        this.to = Option.of(to);
+    }
+
+    public StandardByteRange(int from) {
+        this.from = from;
+        this.to = Option.none();
+    }
+
+    @Override
+    protected String getPartialContent(Response response) throws IOException {
+        int length = getTo(response) - from + 1;
+        byte[] bytes = new byte[length];
+        InputStream in = response.getBody();
+        in.skip(from);
+        in.read(bytes);
+        return new String(bytes);
+    }
+
+    @Override
+    protected String getContentRangeHeader(Response response) {
+        String contentLength = response.getHeader("Content-Length").getOrElse("*");
+        return String.format("bytes %s-%s/%s", from, getTo(response), contentLength);
+    }
+
+    private int getTo(Response response) {
+        return to
+            .filter((pos) -> pos < response.getContentLength())
+            .getOrElse(() -> response.getContentLength() - 1);
+    }
+}

--- a/src/main/java/org/flint/range/SuffixByteRange.java
+++ b/src/main/java/org/flint/range/SuffixByteRange.java
@@ -1,0 +1,38 @@
+package org.flint.range;
+
+import java.io.InputStream;
+import java.io.IOException;
+
+import javaslang.control.Option;
+
+import org.flint.Response;
+import org.flint.StatusCode;
+
+public class SuffixByteRange extends SingleByteRange {
+    private int length;
+
+    public SuffixByteRange(int length) {
+        this.length = length;
+    }
+
+    @Override
+    protected String getPartialContent(Response response) throws IOException {
+        InputStream in = response.getBody();
+        byte[] bytes = new byte[Math.min(length, response.getContentLength())];
+        in.skip(getFrom(response));
+        in.read(bytes);
+        return new String(bytes);
+    }
+
+    @Override
+    protected String getContentRangeHeader(Response response) {
+        int contentLength = Integer.parseInt(response.getHeader("Content-Length").getOrElse("*"));
+        return String.format("bytes %s-%s/%s", getFrom(response), contentLength - 1, contentLength);
+    }
+
+    private int getFrom(Response response) {
+        return Option.of(response.getContentLength() - length)
+            .filter(l -> l >= 0)
+            .getOrElse(0);
+    }
+}

--- a/src/test/java/org/flint/ApplicationTest.java
+++ b/src/test/java/org/flint/ApplicationTest.java
@@ -32,7 +32,7 @@ public class ApplicationTest {
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
-        assertThat(response.getHeader("Content-Length"), equalTo(Option.of("3")));
+        assertThat(response.getContentLength(), equalTo(3));
         assertThat(response.getBodyAsString(), equalTo("foo"));
     }
 
@@ -53,7 +53,7 @@ public class ApplicationTest {
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
-        assertThat(response.getHeader("Content-Length"), equalTo(Option.of("3")));
+        assertThat(response.getContentLength(), equalTo(3));
         assertThat(response.getBodyAsString(), equalTo("foo"));
     }
 
@@ -74,7 +74,7 @@ public class ApplicationTest {
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
-        assertThat(response.getHeader("Content-Length"), equalTo(Option.of("3")));
+        assertThat(response.getContentLength(), equalTo(3));
         assertThat(response.getBodyAsString(), equalTo(""));
     }
 
@@ -95,7 +95,7 @@ public class ApplicationTest {
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
-        assertThat(response.getHeader("Content-Length"), equalTo(Option.of("3")));
+        assertThat(response.getContentLength(), equalTo(3));
         assertThat(response.getBodyAsString(), equalTo("foo"));
     }
 
@@ -116,7 +116,7 @@ public class ApplicationTest {
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
-        assertThat(response.getHeader("Content-Length"), equalTo(Option.of("3")));
+        assertThat(response.getContentLength(), equalTo(3));
         assertThat(response.getBodyAsString(), equalTo("foo"));
     }
 
@@ -137,7 +137,7 @@ public class ApplicationTest {
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
-        assertThat(response.getHeader("Content-Length"), equalTo(Option.of("3")));
+        assertThat(response.getContentLength(), equalTo(3));
         assertThat(response.getBodyAsString(), equalTo("foo"));
     }
 
@@ -160,7 +160,7 @@ public class ApplicationTest {
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.OK));
         assertThat(response.getHeader("Allow"), equalTo(Option.of("GET,POST")));
-        assertThat(response.getHeader("Content-Length"), equalTo(Option.of("3")));
+        assertThat(response.getContentLength(), equalTo(3));
         assertThat(response.getBodyAsString(), equalTo("foo"));
     }
 
@@ -182,7 +182,7 @@ public class ApplicationTest {
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.NO_CONTENT));
         assertThat(response.getHeader("ETag"), equalTo(Option.of("foo")));
-        assertThat(response.getHeader("Content-Length"), equalTo(Option.of("0")));
+        assertThat(response.getContentLength(), equalTo(0));
         assertThat(response.getBodyAsString(), equalTo(""));
     }
 
@@ -209,7 +209,7 @@ public class ApplicationTest {
         Response response = server.handle(request);
 
         assertThat(response.getStatusCode(), equalTo(StatusCode.NOT_FOUND));
-        assertThat(Integer.parseInt(response.getHeader("Content-Length").get()), greaterThan(0));
+        assertThat(response.getContentLength(), greaterThan(0));
         assertThat(response.getBodyAsString(), equalTo(""));
     }
 

--- a/src/test/java/org/flint/ResponseTest.java
+++ b/src/test/java/org/flint/ResponseTest.java
@@ -96,7 +96,7 @@ public class ResponseTest {
         Response response = Response.create();
         response.setBody("foo");
 
-        assertThat(response.getHeader("Content-Length"), equalTo(Option.of("3")));
+        assertThat(response.getContentLength(), equalTo(3));
     }
 
 }

--- a/src/test/java/org/flint/exception/HttpExceptionTest.java
+++ b/src/test/java/org/flint/exception/HttpExceptionTest.java
@@ -33,15 +33,15 @@ public class HttpExceptionTest {
     @Test
     public void itShouldAcceptHeaders() {
         HttpException he = new HttpException(StatusCode.NOT_FOUND);
-        he.setHeader("Content-Length", "3");
-        assertThat(he.getHeader("Content-Length"), equalTo(Option.of("3")));
+        he.setHeader("Content-Type", "image/png");
+        assertThat(he.getHeader("Content-Type"), equalTo(Option.of("image/png")));
     }
 
     @Test
     public void itShouldGiveAllHeaders() {
         HttpException he = new HttpException(StatusCode.NOT_FOUND);
-        he.setHeader("Content-Length", "3");
-        assertThat(he.getHeaders(), equalTo(HashMap.of("Content-Length", "3")));
+        he.setHeader("Content-Type", "image/png");
+        assertThat(he.getHeaders(), equalTo(HashMap.of("Content-Type", "image/png")));
     }
 
 }

--- a/src/test/java/org/flint/parse/RangeRequestsTest.java
+++ b/src/test/java/org/flint/parse/RangeRequestsTest.java
@@ -1,0 +1,48 @@
+package org.flint.parse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+import org.jparsec.error.ParserException;
+
+import org.flint.range.ByteRange;
+import org.flint.range.Range;
+import org.flint.range.StandardByteRange;
+import org.flint.range.SuffixByteRange;
+
+public class RangeRequestsTest {
+
+    @Test
+    public void itShouldAcceptByteRangesInTheRangeHeader() {
+        Range range = RangeRequests.RANGE.parse("bytes=0-4");
+        assertThat(range, instanceOf(StandardByteRange.class));
+    }
+
+    @Test
+    public void itShouldAcceptSuffixByteRangesInTheRangeHeader() {
+        Range range = RangeRequests.RANGE.parse("bytes=-4");
+        assertThat(range, instanceOf(SuffixByteRange.class));
+    }
+
+    @Test
+    public void itShouldNotAcceptOtherRangesInTheRangeHeader() {
+        try {
+            RangeRequests.RANGE.parse("foo=0-4");
+            fail();
+        } catch (ParserException pe) {
+        }
+    }
+
+    @Test
+    public void itShouldNotAcceptInvalidByteRangesInTheRangeHeader() {
+        try {
+            RangeRequests.RANGE.parse("byte=a-d");
+            fail();
+        } catch (ParserException pe) {
+        }
+    }
+
+}

--- a/src/test/java/org/flint/range/RangeMiddlewareTest.java
+++ b/src/test/java/org/flint/range/RangeMiddlewareTest.java
@@ -1,0 +1,143 @@
+package org.flint.range;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+
+import javaslang.control.Option;
+
+import org.flint.OriginForm;
+import org.flint.Request;
+import org.flint.Response;
+import org.flint.StatusCode;
+
+@RunWith(DataProviderRunner.class)
+public class RangeMiddlewareTest {
+
+    private Response response;
+
+    @Before
+    public void setup() {
+        response = Response.create(StatusCode.OK);
+        response.setHeader("Content-Type", "text/plain; charset=utf-8");
+        response.setBody("abcdefghijklmnopqrstuvwxyz");
+    }
+
+    @Test
+    public void itShouldDoNothingIfThereIsNoRangeHeader() {
+        RangeMiddleware range = new RangeMiddleware();
+
+        Request request = new Request("GET", new OriginForm("foo"));
+        Response result = range.apply(request, response);
+
+        assertThat(result.getStatusCode(), equalTo(StatusCode.OK));
+        assertThat(result.getHeader("Content-Range"), equalTo(Option.none()));
+        assertThat(result.getContentLength(), equalTo(26));
+        assertThat(result.getHeader("Content-Type"), equalTo(Option.of("text/plain; charset=utf-8")));
+        assertThat(result.getBodyAsString(), equalTo("abcdefghijklmnopqrstuvwxyz"));
+    }
+
+    @DataProvider
+    public static Object[][] dataProviderMethods() {
+        return new Object[][] {
+            { "HEAD" },
+            { "POST" },
+            { "PUT" },
+            { "DELETE" },
+            { "OPTIONS" }
+        };
+    }
+
+    @Test
+    @UseDataProvider("dataProviderMethods")
+    public void itShouldIgnoreTheRangeHeaderIfTheMethodIsNotGET(String method) {
+        RangeMiddleware range = new RangeMiddleware();
+
+        Request request = new Request(method, new OriginForm("foo"));
+        request.setHeader("Range", "bytes=0-4");
+        Response result = range.apply(request, response);
+
+        assertThat(result.getStatusCode(), equalTo(StatusCode.OK));
+        assertThat(result.getHeader("Content-Range"), equalTo(Option.none()));
+        assertThat(result.getContentLength(), equalTo(26));
+        assertThat(result.getHeader("Content-Type"), equalTo(Option.of("text/plain; charset=utf-8")));
+        assertThat(result.getBodyAsString(), equalTo("abcdefghijklmnopqrstuvwxyz"));
+    }
+
+    @DataProvider
+    public static Object[][] dataProviderStatusCodes() {
+        return new Object[][] {
+            { Response.create(StatusCode.NO_CONTENT), StatusCode.NO_CONTENT },
+            { Response.create(StatusCode.NOT_MODIFIED), StatusCode.NOT_MODIFIED },
+            { Response.create(StatusCode.NOT_FOUND), StatusCode.NOT_FOUND },
+            { Response.create(StatusCode.INTERNAL_SERVER_ERROR), StatusCode.INTERNAL_SERVER_ERROR }
+        };
+    }
+
+    @Test
+    @UseDataProvider("dataProviderStatusCodes")
+    public void itShouldIgnoreTheRangeHeaderIfTheStatusIsNotOK(Response response, int statusCode) {
+        RangeMiddleware range = new RangeMiddleware();
+
+        Request request = new Request("GET", new OriginForm("foo"));
+        request.setHeader("Range", "bytes=0-4");
+        Response result = range.apply(request, response);
+
+        assertThat(result.getStatusCode(), equalTo(statusCode));
+        assertThat(result.getHeader("Content-Range"), equalTo(Option.none()));
+        assertThat(result.getBodyAsString(), equalTo(""));
+    }
+
+    @Test
+    public void itShouldIgnoreARangeHeaderThatItDoesntUnderstand() {
+        RangeMiddleware range = new RangeMiddleware();
+
+        Request request = new Request("GET", new OriginForm("foo"));
+        request.setHeader("Range", "foo=0-4");
+        Response result = range.apply(request, response);
+
+        assertThat(result.getStatusCode(), equalTo(StatusCode.OK));
+        assertThat(result.getHeader("Content-Range"), equalTo(Option.none()));
+        assertThat(result.getContentLength(), equalTo(26));
+        assertThat(result.getHeader("Content-Type"), equalTo(Option.of("text/plain; charset=utf-8")));
+        assertThat(result.getBodyAsString(), equalTo("abcdefghijklmnopqrstuvwxyz"));
+    }
+
+    @Test
+    public void itShouldIgnoreAnInvalidRange() {
+        RangeMiddleware range = new RangeMiddleware();
+
+        Request request = new Request("GET", new OriginForm("foo"));
+        request.setHeader("Range", "bytes=30-35");
+        Response result = range.apply(request, response);
+
+        assertThat(result.getStatusCode(), equalTo(StatusCode.OK));
+        assertThat(result.getHeader("Content-Range"), equalTo(Option.none()));
+        assertThat(result.getContentLength(), equalTo(26));
+        assertThat(result.getHeader("Content-Type"), equalTo(Option.of("text/plain; charset=utf-8")));
+        assertThat(result.getBodyAsString(), equalTo("abcdefghijklmnopqrstuvwxyz"));
+    }
+
+    @Test
+    public void itShouldReturnAPartialContentResponseIfEverythingIsSatisfiable() {
+        RangeMiddleware range = new RangeMiddleware();
+
+        Request request = new Request("GET", new OriginForm("foo"));
+        request.setHeader("Range", "bytes=0-4");
+        Response result = range.apply(request, response);
+
+        assertThat(result.getStatusCode(), equalTo(StatusCode.PARTIAL_CONTENT));
+        assertThat(result.getHeader("Content-Range"), equalTo(Option.of("bytes 0-4/26")));
+        assertThat(result.getContentLength(), equalTo(5));
+        assertThat(result.getHeader("Content-Type"), equalTo(Option.of("text/plain; charset=utf-8")));
+        assertThat(result.getBodyAsString(), equalTo("abcde"));
+    }
+
+}

--- a/src/test/java/org/flint/range/RangeTest.java
+++ b/src/test/java/org/flint/range/RangeTest.java
@@ -1,0 +1,34 @@
+package org.flint.range;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+
+import javaslang.collection.List;
+
+@RunWith(DataProviderRunner.class)
+public class RangeTest {
+
+    @DataProvider
+    public static Object[][] dataProviderRanges() {
+        StandardByteRange range1 = new StandardByteRange(0, 4);
+        StandardByteRange range2 = new StandardByteRange(5, 12);
+
+        return new Object[][] {
+            { List.of(range1), range1 },
+            { List.of(range1, range2), range1 }
+        };
+    }
+
+    @Test
+    @UseDataProvider("dataProviderRanges")
+    public void createByteRangeShouldReturnTheFirstRangeInTheList(List<SingleByteRange> ranges, SingleByteRange expectedRange) {
+        assertThat(Range.createByteRange(ranges), equalTo(expectedRange));
+    }
+
+}

--- a/src/test/java/org/flint/range/StandardByteRangeTest.java
+++ b/src/test/java/org/flint/range/StandardByteRangeTest.java
@@ -1,0 +1,105 @@
+package org.flint.range;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import javaslang.control.Option;
+
+import org.flint.Response;
+import org.flint.StatusCode;
+
+public class StandardByteRangeTest {
+
+    private Response response;
+
+    @Before
+    public void setup() {
+        response = Response.create(StatusCode.OK);
+        response.setHeader("Content-Type", "text/plain; charset=utf-8");
+        response.setBody("abcdefghijklmnopqrstuvwxyz");
+    }
+
+    @Test
+    public void itShouldHandleARangeForTheWholeDocument() throws IOException {
+        StandardByteRange range = new StandardByteRange(0, 25);
+
+        Response result = range.makePartial(response);
+
+        assertThat(result.getStatusCode(), equalTo(StatusCode.PARTIAL_CONTENT));
+        assertThat(result.getHeader("Content-Range"), equalTo(Option.of("bytes 0-25/26")));
+        assertThat(result.getContentLength(), equalTo(26));
+        assertThat(result.getHeader("Content-Type"), equalTo(Option.of("text/plain; charset=utf-8")));
+        assertThat(result.getBodyAsString(), equalTo("abcdefghijklmnopqrstuvwxyz"));
+    }
+
+    @Test
+    public void itShouldHandleARangeForTheBeginningOfTheDocument() throws IOException {
+        StandardByteRange range = new StandardByteRange(0, 4);
+
+        Response result = range.makePartial(response);
+
+        assertThat(result.getStatusCode(), equalTo(StatusCode.PARTIAL_CONTENT));
+        assertThat(result.getHeader("Content-Range"), equalTo(Option.of("bytes 0-4/26")));
+        assertThat(result.getContentLength(), equalTo(5));
+        assertThat(result.getHeader("Content-Type"), equalTo(Option.of("text/plain; charset=utf-8")));
+        assertThat(result.getBodyAsString(), equalTo("abcde"));
+    }
+
+    @Test
+    public void itShouldHandleARangeForTheMiddleOfTheDocument() throws IOException {
+        StandardByteRange range = new StandardByteRange(5, 8);
+
+        Response result = range.makePartial(response);
+
+        assertThat(result.getStatusCode(), equalTo(StatusCode.PARTIAL_CONTENT));
+        assertThat(result.getHeader("Content-Range"), equalTo(Option.of("bytes 5-8/26")));
+        assertThat(result.getContentLength(), equalTo(4));
+        assertThat(result.getHeader("Content-Type"), equalTo(Option.of("text/plain; charset=utf-8")));
+        assertThat(result.getBodyAsString(), equalTo("fghi"));
+    }
+
+    @Test
+    public void itShouldHandleARangeForTheEndOfTheDocument() throws IOException {
+        StandardByteRange range = new StandardByteRange(23, 25);
+
+        Response result = range.makePartial(response);
+
+        assertThat(result.getStatusCode(), equalTo(StatusCode.PARTIAL_CONTENT));
+        assertThat(result.getHeader("Content-Range"), equalTo(Option.of("bytes 23-25/26")));
+        assertThat(result.getContentLength(), equalTo(3));
+        assertThat(result.getHeader("Content-Type"), equalTo(Option.of("text/plain; charset=utf-8")));
+        assertThat(result.getBodyAsString(), equalTo("xyz"));
+    }
+
+    @Test
+    public void itShouldHandleARangeToTheEndOfTheDocument() throws IOException {
+        StandardByteRange range = new StandardByteRange(23);
+
+        Response result = range.makePartial(response);
+
+        assertThat(result.getStatusCode(), equalTo(StatusCode.PARTIAL_CONTENT));
+        assertThat(result.getHeader("Content-Range"), equalTo(Option.of("bytes 23-25/26")));
+        assertThat(result.getContentLength(), equalTo(3));
+        assertThat(result.getHeader("Content-Type"), equalTo(Option.of("text/plain; charset=utf-8")));
+        assertThat(result.getBodyAsString(), equalTo("xyz"));
+    }
+
+    @Test
+    public void itShouldHandleARangePastTheEndOfTheDocument() throws IOException {
+        StandardByteRange range = new StandardByteRange(23, 30);
+
+        Response result = range.makePartial(response);
+
+        assertThat(result.getStatusCode(), equalTo(StatusCode.PARTIAL_CONTENT));
+        assertThat(result.getHeader("Content-Range"), equalTo(Option.of("bytes 23-25/26")));
+        assertThat(result.getContentLength(), equalTo(3));
+        assertThat(result.getHeader("Content-Type"), equalTo(Option.of("text/plain; charset=utf-8")));
+        assertThat(result.getBodyAsString(), equalTo("xyz"));
+    }
+
+}

--- a/src/test/java/org/flint/range/SuffixByteRangeTest.java
+++ b/src/test/java/org/flint/range/SuffixByteRangeTest.java
@@ -1,0 +1,53 @@
+package org.flint.range;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import javaslang.control.Option;
+
+import org.flint.Response;
+import org.flint.StatusCode;
+
+public class SuffixByteRangeTest {
+
+    private Response response;
+
+    @Before
+    public void setup() {
+        response = Response.create(StatusCode.OK);
+        response.setHeader("Content-Type", "text/plain; charset=utf-8");
+        response.setBody("abcdefghijklmnopqrstuvwxyz");
+    }
+
+    @Test
+    public void itShouldHandleARangeInSuffixForm() throws IOException {
+        SuffixByteRange range = new SuffixByteRange(3);
+
+        Response result = range.makePartial(response);
+
+        assertThat(result.getStatusCode(), equalTo(StatusCode.PARTIAL_CONTENT));
+        assertThat(result.getHeader("Content-Range"), equalTo(Option.of("bytes 23-25/26")));
+        assertThat(result.getContentLength(), equalTo(3));
+        assertThat(result.getHeader("Content-Type"), equalTo(Option.of("text/plain; charset=utf-8")));
+        assertThat(result.getBodyAsString(), equalTo("xyz"));
+    }
+
+    @Test
+    public void itShouldHandleASuffixRangePastTheEndOfTheDocument() throws IOException {
+        SuffixByteRange range = new SuffixByteRange(30);
+
+        Response result = range.makePartial(response);
+
+        assertThat(result.getStatusCode(), equalTo(StatusCode.PARTIAL_CONTENT));
+        assertThat(result.getHeader("Content-Range"), equalTo(Option.of("bytes 0-25/26")));
+        assertThat(result.getContentLength(), equalTo(26));
+        assertThat(result.getHeader("Content-Type"), equalTo(Option.of("text/plain; charset=utf-8")));
+        assertThat(result.getBodyAsString(), equalTo("abcdefghijklmnopqrstuvwxyz"));
+    }
+
+}


### PR DESCRIPTION
RFC-7233 states that a server may ignore a range request for any reason.
If a range is bad or is unsupported for any reason, a normal 200 OK will
be returned.

This implementation fully implements single byte ranges including suffix
form.

Future work would entail multiple byte range support and returning 416
Range Not Satisfiable responses when possible.  Currently, multiple
range requests will be accepted, but only the first range will be
considered.