### PR TITLE
Fix bug causing 400 responses on mac

### DIFF
--- a/src/main/java/org/flint/parse/Http.java
+++ b/src/main/java/org/flint/parse/Http.java
@@ -72,11 +72,8 @@ public class Http {
     public static final Parser<String> FIELD_NAME = TOKEN.label("field-name");
 
     public static final Parser<String> FIELD_CONTENT = Parsers.sequence(
-            FIELD_VCHAR,
-            Parsers.sequence(
-                Parsers.or(SP, HTAB).many1(),
-                FIELD_VCHAR
-            ).optional()
+            Parsers.or(SP, HTAB).many(),
+            FIELD_VCHAR
         ).label("field-content").source();
 
     public static final Parser<String> OBS_FOLD = Parsers.sequence(

--- a/src/test/java/org/flint/parse/HttpParserTest.java
+++ b/src/test/java/org/flint/parse/HttpParserTest.java
@@ -71,7 +71,8 @@ public class HttpParserTest {
     public static Object[][] dataProviderHeaders() {
         return new Object[][] {
             { "Content-Length: 12", Tuple.of("Content-Length", "12") },
-            { "Content-Type: text/plain; charset=utf-8", Tuple.of("Content-Type", "text/plain; charset=utf-8") }
+            { "Content-Type: text/plain; charset=utf-8", Tuple.of("Content-Type", "text/plain; charset=utf-8") },
+            { "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.96 Safari/537.36", Tuple.of("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.96 Safari/537.36") }
         };
     }
 


### PR DESCRIPTION
This turned out to be a bug in the HTTP specification.  The way the ABNF
is written, it breaks on space separated header field strings if one of
those strings is one character long.  It was breaking when trying to
parse the `User-Agent` header which included the string "Mac OS X 10_".
It failed to parse past the "X".